### PR TITLE
Replace fasthash with murmur3

### DIFF
--- a/core/amt-ipld/Cargo.toml
+++ b/core/amt-ipld/Cargo.toml
@@ -21,5 +21,6 @@ blockstore = { package = "rust-ipfs-blockstore", path = "../ipfs/blockstore" }
 block-format = { package = "rust-block-format", path = "../block-format" }
 
 [dev-dependencies]
-util = { package = "rust-ipfs-util", path = "../util" }
+matches = "0.1"
 rand = "0.7"
+util = { package = "rust-ipfs-util", path = "../util" }

--- a/core/amt-ipld/Cargo.toml
+++ b/core/amt-ipld/Cargo.toml
@@ -1,17 +1,19 @@
 [package]
 name = "rust-amt-ipld"
 version = "0.1.0"
-authors = ["Aten <jincxmain@gmail.com>"]
+authors = ["PolkaX <https://github.com/PolkaX>"]
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+license = "MIT/Apache-2.0"
+repository = "https://github.com/PolkaX/rust-ipfs"
+description = "Implementation of the ipld amt"
+keywords = ["ipfs", "ipld", "amt"]
 
 [dependencies]
-thiserror = "1.0"
 serde = "1.0"
 serde_cbor = { git = "https://github.com/PolkaX/cbor", branch = "f64ser-hack", features = ["tags"] }
 serde_bytes = "0.11"
-archery = "0.3"
+thiserror = "1.0"
 
 cid = { package = "rust-cid", path = "../cid", features = ["hascid", "serde_support"] }
 ipld-cbor = { package = "rust-ipld-cbor", path = "../ipld/cbor" }

--- a/core/amt-ipld/src/lib.rs
+++ b/core/amt-ipld/src/lib.rs
@@ -1,7 +1,5 @@
 // Copyright 2019-2020 PolkaX. Licensed under MIT or Apache-2.0.
 
-#![cfg_attr(test, feature(matches_macro))]
-
 mod blocks;
 mod error;
 mod node;

--- a/core/amt-ipld/src/tests/amt_test.rs
+++ b/core/amt-ipld/src/tests/amt_test.rs
@@ -1,3 +1,5 @@
+use matches::matches;
+
 use super::*;
 
 #[test]

--- a/core/hamt-ipld/Cargo.toml
+++ b/core/hamt-ipld/Cargo.toml
@@ -10,15 +10,14 @@ description = "Implementation of the ipld hamt"
 keywords = ["ipfs", "ipld", "hamt"]
 
 [dependencies]
-fasthash = "0.4"
-thiserror = "1.0"
+bigint = "4.4"
+bytes = { version = "0.5", features = ["serde"] }
+murmur3 = "0.5"
 serde = "1.0"
 serde_derive = "1.0"
 serde_bytes = "0.11"
-serde_tuple = "0.4"
 serde_cbor = { git = "https://github.com/PolkaX/cbor", branch = "f64ser-hack", features = ["tags"] }
-bytes = { version = "0.5", features = ["serde"] }
-bigint = { version = "4.4" }
+thiserror = "1.0"
 
 multihash = { package = "rust-multihash", path = "../multihash" }
 

--- a/core/hamt-ipld/Cargo.toml
+++ b/core/hamt-ipld/Cargo.toml
@@ -26,9 +26,10 @@ cid = { package = "rust-cid", path = "../cid", features = ["hascid", "serde_supp
 ipld-cbor = { package = "rust-ipld-cbor", path = "../ipld/cbor", features = ["bigint"] }
 
 [dev-dependencies]
-util = { package = "rust-ipfs-util", path = "../util" }
-serde_json = "1.0"
+matches = "0.1"
 rand = "0.7"
+serde_json = "1.0"
+util = { package = "rust-ipfs-util", path = "../util" }
 
 [features]
 test-hash = []

--- a/core/hamt-ipld/src/lib.rs
+++ b/core/hamt-ipld/src/lib.rs
@@ -2,7 +2,6 @@
 
 //! A implementation of `ipld hamt` in Rust.
 
-#![cfg_attr(test, feature(matches_macro))]
 #![allow(clippy::bool_comparison, clippy::type_complexity, clippy::or_fun_call)]
 
 mod error;

--- a/core/hamt-ipld/src/tests/hamt_test.rs
+++ b/core/hamt-ipld/src/tests/hamt_test.rs
@@ -2,6 +2,7 @@
 
 use std::time::Instant;
 
+use matches::matches;
 use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
 

--- a/core/hamt-ipld2/Cargo.toml
+++ b/core/hamt-ipld2/Cargo.toml
@@ -10,16 +10,16 @@ description = "Implementation of the ipld hamt"
 keywords = ["ipfs", "ipld", "hamt"]
 
 [dependencies]
-fasthash = "0.4"
-thiserror = "1.0"
+archery = "0.3"
+bigint = "4.4"
+bytes = { version = "0.5", features = ["serde"] }
+murmur3 = "0.5"
 serde = "1.0"
 serde_derive = "1.0"
 serde_bytes = "0.11"
 serde_tuple = "0.4"
 serde_cbor = { git = "https://github.com/PolkaX/cbor", branch = "f64ser-hack", features = ["tags"] }
-bytes = { version = "0.5", features = ["serde"] }
-archery = "0.3"
-bigint = { version = "4.4" }
+thiserror = "1.0"
 
 multihash = { package = "rust-multihash", path = "../multihash" }
 

--- a/core/hamt-ipld2/Cargo.toml
+++ b/core/hamt-ipld2/Cargo.toml
@@ -28,9 +28,10 @@ cid = { package = "rust-cid", path = "../cid", features = ["hascid", "serde_supp
 ipld-cbor = { package = "rust-ipld-cbor", path = "../ipld/cbor", features = ["bigint"] }
 
 [dev-dependencies]
-util = { package = "rust-ipfs-util", path = "../util" }
-serde_json = "1.0"
+matches = "0.1"
 rand = "0.7"
+serde_json = "1.0"
+util = { package = "rust-ipfs-util", path = "../util" }
 
 [features]
 test-hash = []

--- a/core/hamt-ipld2/src/lib.rs
+++ b/core/hamt-ipld2/src/lib.rs
@@ -2,7 +2,6 @@
 
 //! A implementation of `ipld hamt` in Rust.
 
-#![cfg_attr(test, feature(matches_macro))]
 #![allow(clippy::bool_comparison, clippy::type_complexity)]
 
 mod error;

--- a/core/hamt-ipld2/src/tests/hamt_test.rs
+++ b/core/hamt-ipld2/src/tests/hamt_test.rs
@@ -5,6 +5,7 @@ use std::ops::Deref;
 use std::time::Instant;
 
 use archery::SharedPointerKind;
+use matches::matches;
 use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
 


### PR DESCRIPTION
Signed-off-by: koushiro <koushiro.cqx@gmail.com>

* Replace `fasthash` with `murmur3`
* Remove some useless dependencies
* Replace `matches_macro` feature with the crate `matches` (The feature `matches_macro` will stabilize in rust 1.42)